### PR TITLE
Corrected dependency documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add dependency:
 
 ```
 dependencies {
-    compile 'io.github.novacrypto:SecureString:2019.01.27@jar'
+    implementation 'io.github.novacrypto:securestring:2019.01.27'
 }
 
 ```


### PR DESCRIPTION
This artifact has been published to Bintray as `io.github.novacrypto:securestring:2019.01.27` which is case-sensitive. So using the documentation, as is, did not work. Also, "compile" is deprecated in the latest version of gradle. Lastly, @jar is not needed.